### PR TITLE
Fix Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ env:
 before_install:
   - git clone https://github.com/elixir-lang/elixir
   - cd elixir
-  - git checkout v1.3
+  - git checkout v1.4.2
   - make clean
   - make
   - cd ..


### PR DESCRIPTION
`nerves_bootstrap` now requires Elixir `~>1.4.0`.