### PR TITLE
Enable heart on the regression tests

### DIFF
--- a/test/rel/vm.args
+++ b/test/rel/vm.args
@@ -15,11 +15,22 @@
 ## See http://erlang.org/doc/man/kernel_app.html for additional options
 -kernel shell_history enabled
 
+## Enable heartbeat monitoring of the Erlang runtime system
+-heart -env HEART_BEAT_TIMEOUT 30
+
 ## Start the Elixir shell
 
 -noshell
 -user Elixir.IEx.CLI
 
-## Options added after -extra are interpreted as plain arguments and
-## can be retrieved using :init.get_plain_arguments().
+## Enable colors in the shell
+-elixir ansi_enabled true
+
+## Options added after -extra are interpreted as plain arguments and can be
+## retrieved using :init.get_plain_arguments(). Options before the "--" are
+## interpreted by Elixir and anything afterwards is left around for other IEx
+## and user applications.
 -extra --no-halt
+#--
+#--dot-iex /etc/iex.exs
+


### PR DESCRIPTION
I tested the hardware watchdog on a BBGW and it works. We may want to tweak the settings, but it seems plenty good to enable on the regression tests.