### PR TITLE
nerves_system_br: bump to 1.0.1

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -48,8 +48,8 @@ defmodule NervesSystemBbb.MixProject do
   defp deps do
     [
       {:nerves, "~> 1.0", runtime: false},
-      {:nerves_system_br, "~> 1.0.0", runtime: false},
-      {:nerves_toolchain_arm_unknown_linux_gnueabihf, "~> 1.0.0", runtime: false},
+      {:nerves_system_br, "1.0.1", runtime: false},
+      {:nerves_toolchain_arm_unknown_linux_gnueabihf, "1.0.0", runtime: false},
       {:nerves_system_linter, "~> 0.3.0", runtime: false},
       {:ex_doc, "~> 0.18", only: :dev}
     ]


### PR DESCRIPTION
This also locks the deps on the toolchain and system in the mix.exs.
Since neither nerves_system_br nor the toolchain can be guaranteed to
follow semver, locking the dependencies is necessary to prevent breaking
surprises from running 'mix deps.update --all'.