### PR TITLE
Support hostname generation from the serial number

### DIFF
--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -53,9 +53,14 @@
 # Erlang release search path
 -r /srv/erlang
 
-# Assign a unique hostname based on the board id
--d "/usr/bin/boardid -b bbb -n 4"
--n nerves-%.4s
+# Assign a unique hostname based on a board identifier. The logic is:
+# 1. Check the U-boot environment block for a key named "serial_number"
+# 2. Use the serial number programmed into the EEPROM. All official
+#    Beagleboard.org hardware supports this.
+# 3. Use the MAC address of the first Ethernet port. This is useful for
+#    custom boards that don't include the EEPROM or leave it unprogrammed.
+-d "/usr/bin/boardid -b uboot_env -f /dev/mmcblk0 -k 0x100000 -l 0x2000 -u serial_number -b bbb -n 4 -b macaddr -n 4"
+-n nerves-%s
 
 # If using shoehorn (https://github.com/nerves-project/shoehorn), start the
 # shoehorn OTP release up first. If shoehorn isn't around, erlinit fails back


### PR DESCRIPTION
This also adds a fallback for boards with unprogrammed EEPROMs like is
often the case with custom hardware.