### PR TITLE
Save the firmware's UUID on upgrades

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -202,6 +202,7 @@ task complete {
         uboot_setenv(uboot-env, "a.nerves_fw_author", ${NERVES_FW_AUTHOR})
         uboot_setenv(uboot-env, "a.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
         uboot_setenv(uboot-env, "a.nerves_fw_misc", ${NERVES_FW_MISC})
+        uboot_setenv(uboot-env, "a.nerves_fw_uuid", "\${FWUP_META_UUID}")
 
         # Support setting device serial numbers when creating MicroSD cards.
         # Note that the '$' is escaped so that environment variable replacement
@@ -261,6 +262,7 @@ task upgrade.a {
         uboot_unsetenv(uboot-env, "a.nerves_fw_version")
         uboot_unsetenv(uboot-env, "a.nerves_fw_platform")
         uboot_unsetenv(uboot-env, "a.nerves_fw_architecture")
+        uboot_unsetenv(uboot-env, "a.nerves_fw_uuid")
 
         # Reset the previous contents of the A boot partition
         fat_mkfs(${BOOT_A_PART_OFFSET}, ${BOOT_A_PART_COUNT})
@@ -297,6 +299,7 @@ task upgrade.a {
         uboot_setenv(uboot-env, "a.nerves_fw_author", ${NERVES_FW_AUTHOR})
         uboot_setenv(uboot-env, "a.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
         uboot_setenv(uboot-env, "a.nerves_fw_misc", ${NERVES_FW_MISC})
+        uboot_setenv(uboot-env, "a.nerves_fw_uuid", "\${FWUP_META_UUID}")
 
 	# Switch over to boot the new firmware
         uboot_setenv(uboot-env, "nerves_fw_active", "a")
@@ -323,6 +326,7 @@ task upgrade.b {
         uboot_unsetenv(uboot-env, "b.nerves_fw_version")
         uboot_unsetenv(uboot-env, "b.nerves_fw_platform")
         uboot_unsetenv(uboot-env, "b.nerves_fw_architecture")
+        uboot_unsetenv(uboot-env, "b.nerves_fw_uuid")
 
         # Reset the previous contents of the B boot partition
         fat_mkfs(${BOOT_B_PART_OFFSET}, ${BOOT_B_PART_COUNT})
@@ -358,6 +362,7 @@ task upgrade.b {
         uboot_setenv(uboot-env, "b.nerves_fw_author", ${NERVES_FW_AUTHOR})
         uboot_setenv(uboot-env, "b.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
         uboot_setenv(uboot-env, "b.nerves_fw_misc", ${NERVES_FW_MISC})
+        uboot_setenv(uboot-env, "b.nerves_fw_uuid", "\${FWUP_META_UUID}")
 
 	# Switch over to boot the new firmware
         uboot_setenv(uboot-env, "nerves_fw_active", "b")

--- a/mix.exs
+++ b/mix.exs
@@ -48,7 +48,7 @@ defmodule NervesSystemBbb.MixProject do
   defp deps do
     [
       {:nerves, "~> 1.0", runtime: false},
-      {:nerves_system_br, "1.2.0", runtime: false},
+      {:nerves_system_br, "1.2.2", runtime: false},
       {:nerves_toolchain_arm_unknown_linux_gnueabihf, "1.0.0", runtime: false},
       {:nerves_system_linter, "~> 0.3.0", runtime: false},
       {:ex_doc, "~> 0.18", only: :dev}

--- a/mix.lock
+++ b/mix.lock
@@ -3,7 +3,7 @@
   "earmark": {:hex, :earmark, "1.2.5", "4d21980d5d2862a2e13ec3c49ad9ad783ffc7ca5769cf6ff891a4553fbaae761", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.18.3", "f4b0e4a2ec6f333dccf761838a4b253d75e11f714b85ae271c9ae361367897b7", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "nerves": {:hex, :nerves, "1.0.1", "06e311584bf346622afc37ffd6f0eb581288c918ed71b8a7a14f230062eabf31", [:mix], [{:distillery, "~> 1.4", [hex: :distillery, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: true]}], "hexpm"},
-  "nerves_system_br": {:hex, :nerves_system_br, "1.2.0", "0133c5b560637bb700620d252904d2c87f38adbca70f0b7876a8cdd1f363808e", [:mix], [], "hexpm"},
+  "nerves_system_br": {:hex, :nerves_system_br, "1.2.2", "41166311f4d492a4992a6131dca456d4270fb3d216b2673d3a37b1434d30f1d2", [:mix], [], "hexpm"},
   "nerves_system_linter": {:hex, :nerves_system_linter, "0.3.0", "84e0f63c8ac196b16b77608bbe7df66dcf352845c4e4fb394bffd2b572025413", [:mix], [], "hexpm"},
   "nerves_toolchain_arm_unknown_linux_gnueabihf": {:hex, :nerves_toolchain_arm_unknown_linux_gnueabihf, "1.0.0", "39da5b503b977a594c9e386ca16a50c433b333797bc30ac941fd402ce1832274", [:mix], [{:nerves, "~> 1.0", [hex: :nerves, repo: "hexpm", optional: false]}, {:nerves_toolchain_ctng, "~> 1.4", [hex: :nerves_toolchain_ctng, repo: "hexpm", optional: false]}], "hexpm"},
   "nerves_toolchain_ctng": {:hex, :nerves_toolchain_ctng, "1.4.0", "ec844dd286a5281223e023edb1359c8763fef79a3af9daac45397713cff1cb88", [:mix], [{:nerves, "~> 1.0", [hex: :nerves, repo: "hexpm", optional: false]}], "hexpm"},


### PR DESCRIPTION
This will be what it looks like to track the firmware UUID once nerves_system_br 1.2.2 is released.