### PR TITLE
Move boardid configuration out of erlinit.config

### DIFF
--- a/rootfs_overlay/etc/boardid.config
+++ b/rootfs_overlay/etc/boardid.config
@@ -1,0 +1,15 @@
+# boardid.config
+
+# Read the serial number from the U-boot environment block. The variable
+# "nerves_serial_number" is the desired variable to use. "serial_number" is
+# checked as a backup.
+-b uboot_env -u nerves_serial_number
+-b uboot_env -u serial_number
+
+# Use the serial number programmed into the EEPROM. All official
+# Beagleboard.org hardware supports this.
+-b bbb -n 4
+
+# Use the MAC address of the first Ethernet port. This is useful for
+# custom boards that don't include the EEPROM or leave it unprogrammed.
+-b macaddr -n 4

--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -53,13 +53,9 @@
 # Erlang release search path
 -r /srv/erlang
 
-# Assign a unique hostname based on a board identifier. The logic is:
-# 1. Check the U-boot environment block for a key named "nerves_serial_number"
-# 2. Use the serial number programmed into the EEPROM. All official
-#    Beagleboard.org hardware supports this.
-# 3. Use the MAC address of the first Ethernet port. This is useful for
-#    custom boards that don't include the EEPROM or leave it unprogrammed.
--d "/usr/bin/boardid -b uboot_env -u nerves_serial_number -b uboot_env -u serial_number -b bbb -n 4 -b macaddr -n 4"
+# Assign a hostname of the form "nerves-<serial_number>".
+# See /etc/boardid.config for locating the serial number.
+-d /usr/bin/boardid
 -n nerves-%s
 
 # If using shoehorn (https://github.com/nerves-project/shoehorn), start the


### PR DESCRIPTION
This makes it possible to call "boardid" from anywhere and get the
intended ID.