### PR TITLE
Update DTO customization notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,19 @@ match upstream. This means that most of the upstream documentation on device
 tree is usable. The difference is that instead of using `/boot/uEnv.txt` to
 customize the overlays, you need to set the variables in the U-Boot environment
 block. This can be done by running `cmd("fw_setenv <key> <value>")` from the IEx
-prompt or by adding the variables to the `fwup.conf` file.
+prompt or by adding the variables to the `fwup_include/provisioning.conf` file.
+
+For example, at the IEx prompt:
+
+```elixir
+cmd("fw_setenv uboot_overlay_addr7 /lib/firmware/BB-UART1-00A0.dtbo")
+```
+
+Or by updating the configuration file:
+
+```
+uboot_setenv(uboot-env, "uboot_overlay_addr7", "/lib/firmware/BB-UART1-00A0.dtbo")
+```
 
 See
 [elinux.org/Beagleboard:BeagleBoneBlack_Debian](https://elinux.org/Beagleboard:BeagleBoneBlack_Debian#U-Boot_.2Fboot.2FuEnv.txt_configuration)
@@ -178,7 +190,7 @@ for documentation on the variables.
 
 The BBB's Universal device tree overlay lets you configure pins at runtime. This
 system enables the universal overlay by default. See the
-`enable_uboot_cape_universal` setting in the default `fwup.conf` file.
+`enable_uboot_cape_universal` setting in the default `fwup_include/provisioning.conf` file.
 
 See
 [beaglebone-universal-io](https://github.com/cdsteinkuehler/beaglebone-universal-io)


### PR DESCRIPTION
Hello,

Working off v2.3.0, I noticed that `fwup_include/provisioning.conf` has examples for customizing the device tree overlays loaded during boot, however the documentation mentions that DTO customizations should be made in `fwup.conf`.

This is a small documentation change to suggest overlay customizations should go in `provisioning.conf` instead of `fwup.conf`. I've also attached examples for enabling UART1, as the process wasn't fully clear to me until I came across `provisioning.conf` which contained some examples.

Thanks for this great project!

Best regards,
Thomas