### PR TITLE
Fix broken links in Github-aware docs

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -2,4 +2,4 @@
 
 Please refer to the [Nerves Project Code of Conduct], which applies to all `nerves-project` repositories.
 
-[Nerves Project Code of Conduct]: https://github.com/nerves-project/nerves/blob/master/CODE_OF_CONDUCT.md
+[Nerves Project Code of Conduct]: https://github.com/nerves-project/nerves/blob/master/.github/CODE_OF_CONDUCT.md

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,4 +2,4 @@
 
 Please refer to the [Nerves Project Contributing Guide], which applies to all `nerves-project` repositories.
 
-[Nerves Project Contributing Guide]: https://github.com/nerves-project/nerves/blob/master/CONTRIBUTING.md
+[Nerves Project Contributing Guide]: https://github.com/nerves-project/nerves/blob/master/.github/CONTRIBUTING.md


### PR DESCRIPTION
Hi there,

This PR fixes links to the Code of Conduct and Contributing docs.

Best regards,
Thomas