### PR TITLE
Mount cgroup control folders

### DIFF
--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -49,6 +49,9 @@
 #       initializing any expected files and folders.
 -m /dev/mmcblk0p1:/mnt/boot:vfat:ro,nodev,noexec,nosuid:
 -m /dev/mmcblk0p4:/root:f2fs:nodev:
+-m tmpfs:/sys/fs/cgroup:tmpfs:nodev,noexec,nosuid:mode=755,size=1024k
+-m cpu:/sys/fs/cgroup/cpu:cgroup:nodev,noexec,nosuid:cpu
+-m memory:/sys/fs/cgroup/memory:cgroup:nodev,noexec,nosuid:memory
 
 # Erlang release search path
 -r /srv/erlang


### PR DESCRIPTION
The cgroup drivers have been enabled in the kernel for a while. This
saves the manual step of mounting the control files so that projects
using cgroups can work more easily out-of-the-box.