### PR TITLE
Add package vendor

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,7 @@
 defmodule NervesSystemBbb.MixProject do
   use Mix.Project
 
+  @github_organization "nerves-project"
   @app :nerves_system_bbb
   @version Path.join(__DIR__, "VERSION")
            |> File.read!()
@@ -35,7 +36,7 @@ defmodule NervesSystemBbb.MixProject do
     [
       type: :system,
       artifact_sites: [
-        {:github_releases, "nerves-project/#{@app}"}
+        {:github_releases, "#{@github_organization}/#{@app}"}
       ],
       build_runner_opts: build_runner_opts(),
       platform: Nerves.System.BR,
@@ -66,7 +67,7 @@ defmodule NervesSystemBbb.MixProject do
     [
       files: package_files(),
       licenses: ["Apache 2.0"],
-      links: %{"GitHub" => "https://github.com/nerves-project/#{@app}"}
+      links: %{"GitHub" => "https://github.com/#{@github_organization}/#{@app}"}
     ]
   end
 


### PR DESCRIPTION
Whenever someone wants to create a custom package they need to modify the artifact and links section of the `mix.exs`. While it's trivial it's easy to forget and adds complications for new users. 

I think adding a `@vendor` to the Nerves projects would help simplify documentation. Making a custom image and artifact would only require informing them to change the `@vendor`. 

If this idea seems fine, I could also submit a PR to update the "custom image" documentation. 
