### PR TITLE
Add note about traveling MAC address issue

### DIFF
--- a/uboot/uboot.env
+++ b/uboot/uboot.env
@@ -17,6 +17,24 @@
 #
 # See U-Boot/include/configs/ti_armv7_common.h and
 # U-Boot/include/configs/am335x_evm.h for most of what's below.
+#
+# IMPORTANT:
+# Calling saveenv saves everything. Some of the variables it saves override
+# automatically detected defaults and you can't know whether the variable was
+# supplied automatically or via the saved environment. There is no way to
+# selectively save environment variables. Here are problematic variables:
+#
+# * ethaddr
+# * eth1addr
+# * board_name
+# * board_rev
+# * board_serial
+#
+# If you move MicroSD cards around between boards, you currently need to clear
+# those variables out so that they're detected again. The most visible issue is
+# that Ethernet MAC addresses will travel with MicroSD cards. See
+# https://github.com/nerves-project/nerves_system_bbb/issues/151.
+
 
 #
 # Nerves variables


### PR DESCRIPTION
This doesn't fix the issue, but it puts a note where it may be seen in
case it affects other U-Boot environment variables.

See https://github.com/nerves-project/nerves_system_bbb/issues/151