### PR TITLE
Disable UIO overlay by default

### DIFF
--- a/fwup_include/provisioning.conf
+++ b/fwup_include/provisioning.conf
@@ -41,7 +41,8 @@ uboot_setenv(uboot-env, "enable_uboot_overlays", "1")
 ###pru_rproc (4.14.x-ti kernel)
 #uboot_setenv(uboot-env, "uboot_overlay_pru", "/lib/firmware/AM335X-PRU-RPROC-4-14-TI-00A0.dtbo")
 ###pru_uio (4.4.x-ti, 4.14.x-ti & mainline/bone kernel)
-uboot_setenv(uboot-env, "uboot_overlay_pru", "/lib/firmware/AM335X-PRU-UIO-00A0.dtbo")
+# NOTE: this overlay dumps an exception trace on boot in recent kernels
+#uboot_setenv(uboot-env, "uboot_overlay_pru", "/lib/firmware/AM335X-PRU-UIO-00A0.dtbo")
 ###
 ###Cape Universal Enable
 uboot_setenv(uboot-env, "enable_uboot_cape_universal", "1")


### PR DESCRIPTION
This appears to be benign if you're not using UIO, but it's disturbing
nonetheless.

Fixes:

```
[    3.796152] [<c010bf04>] (unwind_backtrace) from [<c0109a14>] (show_stack+0x10/0x14)
[    3.803973] [<c0109a14>] (show_stack) from [<c02b5064>] (sysfs_warn_dup+0x54/0x60)
[    3.811610] [<c02b5064>] (sysfs_warn_dup) from [<c02b53dc>] (sysfs_do_create_link_sd+0x100/0x104)
[    3.820552] [<c02b53dc>] (sysfs_do_create_link_sd) from [<c0469ed8>] (bus_add_device+0x60/0xf0)
[    3.829320] [<c0469ed8>] (bus_add_device) from [<c04659d8>] (device_add+0x29c/0x798)
[    3.837131] [<c04659d8>] (device_add) from [<c056ae98>] (of_platform_device_create_pdata+0x9c/0xd0)
[    3.846245] [<c056ae98>] (of_platform_device_create_pdata) from [<c056b074>] (of_platform_bus_create+0x19c/0x23c)
[    3.856579] [<c056b074>] (of_platform_bus_create) from [<c056b2d0>] (of_platform_populate+0x70/0xe0)
[    3.865783] [<c056b2d0>] (of_platform_populate) from [<c03c0ab0>] (sysc_probe+0xebc/0x1568)
[    3.874220] [<c03c0ab0>] (sysc_probe) from [<c046cf40>] (platform_drv_probe+0x48/0x98)
[    3.882210] [<c046cf40>] (platform_drv_probe) from [<c046add4>] (really_probe+0xf0/0x49c)
[    3.890454] [<c046add4>] (really_probe) from [<c046b480>] (driver_probe_device+0x5c/0xb4)
[    3.898698] [<c046b480>] (driver_probe_device) from [<c0468dc0>] (bus_for_each_drv+0x80/0xd0)
[    3.907319] [<c0468dc0>] (bus_for_each_drv) from [<c046b250>] (__device_attach+0xd0/0x18c)
[    3.915650] [<c046b250>] (__device_attach) from [<c0469fec>] (bus_probe_device+0x84/0x8c)
[    3.923892] [<c0469fec>] (bus_probe_device) from [<c046a418>] (deferred_probe_work_func+0x78/0xa4)
[    3.932930] [<c046a418>] (deferred_probe_work_func) from [<c013ebb0>] (process_one_work+0x1b4/0x444)
[    3.942136] [<c013ebb0>] (process_one_work) from [<c013f08c>] (worker_thread+0x24c/0x60c)
[    3.950385] [<c013f08c>] (worker_thread) from [<c0144950>] (kthread+0x138/0x140)
[    3.957842] [<c0144950>] (kthread) from [<c0100148>] (ret_from_fork+0x14/0x2c)
[    3.965113] Exception stack(0xc1353fb0 to 0xc1353ff8)
[    3.970208] 3fa0:                                     00000000 00000000 00000000 00000000
[    3.978449] 3fc0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    3.986730] 3fe0: 00000000 00000000 00000000 00000000 00000013 00000000
```
