### PR TITLE
Allow kernel includes for device tree overlays

### DIFF
--- a/package/extra-dts/extra-dts.mk
+++ b/package/extra-dts/extra-dts.mk
@@ -7,13 +7,13 @@
 # Remember to bump the version when anything changes in this
 # directory.
 EXTRA_DTS_SOURCE =
-EXTRA_DTS_VERSION = 0.0.1
+EXTRA_DTS_VERSION = 0.0.2
 EXTRA_DTS_DEPENDENCIES = host-dtc
 
 define EXTRA_DTS_BUILD_CMDS
 	cp $(NERVES_DEFCONFIG_DIR)/package/extra-dts/*.dts* $(@D)
         for filename in $(@D)/*.dts; do \
-            $(CPP) -I$(@D) -nostdinc -undef -D__DTS__ -x assembler-with-cpp $$filename | \
+            $(CPP) -I$(@D) -I $(LINUX_SRCDIR)include -I $(LINUX_SRCDIR)arch -nostdinc -undef -D__DTS__ -x assembler-with-cpp $$filename | \
               $(HOST_DIR)/usr/bin/dtc -Wno-unit_address_vs_reg -@ -I dts -O dtb -b 0 -o $${filename%.dts}.dtbo || exit 1; \
         done
 endef


### PR DESCRIPTION
Fixes #271 

This change allows (additional) `*.dts` files to reference Linux Kernel `*.dts` files and/or preprocessor macros.