### PR TITLE
Use long serial numbers by default

### DIFF
--- a/rootfs_overlay/etc/boardid.config
+++ b/rootfs_overlay/etc/boardid.config
@@ -8,12 +8,12 @@
 
 # Use the serial number programmed into the EEPROM. All official
 # Beagleboard.org hardware supports this.
--b bbb -n 4
+-b bbb
 
 # Use the serial number reported in /proc/cpuinfo. This works on
 # the TI AM3358 SDK and derivatives.
--b cpuinfo -n 4
+-b cpuinfo
 
 # Use the MAC address of the first Ethernet port. This is useful for
 # custom boards that don't include the EEPROM or leave it unprogrammed.
--b macaddr -n 4
+-b macaddr

--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -69,10 +69,10 @@
 # Erlang release search path
 -r /srv/erlang
 
-# Assign a hostname of the form "nerves-<serial_number>".
+# Assign a hostname of the form "nerves-<last 4 chars of the serial number>".
 # See /etc/boardid.config for locating the serial number.
 -d /usr/bin/boardid
--n nerves-%s
+-n nerves-%-.4s
 
 # If using shoehorn (https://github.com/nerves-project/shoehorn), start the
 # shoehorn OTP release up first. If shoehorn isn't around, erlinit fails back


### PR DESCRIPTION
Serial numbers previously were limited to 4 characters for ease of
typing for new users. Now that they're used more places, they're far too
short.
