### PR TITLE
Update HexDoc URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -304,7 +304,7 @@ This is a Buildroot version update that appears to mostly contain bug and
 security fixes. It should be a low risk upgrade from v2.18.2.
 
 * New features
-  * Support factory reset, preventing firmware reverts. See [Nerves.Runtime.FwupOps](https://hexdocs.pm/nerves_runtime/Nerves.Runtime.FwupOps.html)
+  * Support factory reset, preventing firmware reverts. See [Nerves.Runtime.FwupOps](https://nerves-runtime.hexdocs.pm/Nerves.Runtime.FwupOps.html)
 
 * Updated dependencies
   * [nerves_system_br v1.24.0](https://github.com/nerves-project/nerves_system_br/releases/tag/v1.24.0)
@@ -720,7 +720,7 @@ This release updates to [Buildroot
 
 * New features
   * Added support for updating the root filesystem using firmware patches.
-    See the [firmware patch docs](https://hexdocs.pm/nerves/experimental-features.html#content) for more information.
+    See the [firmware patch docs](https://nerves.hexdocs.pm/experimental-features.html#content) for more information.
 
 ## v2.7.2
 
@@ -1175,7 +1175,7 @@ publish scripts.
   * Automount the boot partition readonly at `/boot`
   * Support for reverting firmware.
 
-    See [Reverting Firmware](https://hexdocs.pm/nerves_runtime/readme.html#reverting-firmware) for more info on reverting firmware.
+    See [Reverting Firmware](https://nerves-runtime.hexdocs.pm/readme.html#reverting-firmware) for more info on reverting firmware.
 
     See [fwup-revert.conf](https://github.com/nerves-project/nerves_system_rpi/blob/master/fwup-revert.conf) for more information on how fwup handles reverting.
 

--- a/README.md
+++ b/README.md
@@ -31,12 +31,12 @@ and [PocketBeagle](https://beagleboard.org/pocket).
 
 The most common way of using this Nerves System is create a project with `mix
 nerves.new` and to export `MIX_TARGET=bbb`. See the [Getting started
-guide](https://hexdocs.pm/nerves/getting-started.html#creating-a-new-nerves-app)
+guide](https://nerves.hexdocs.pm/getting-started.html#creating-a-new-nerves-app)
 for more information.
 
 If you need custom modifications to this system for your device, clone this
 repository and update as described in [Making custom
-systems](https://hexdocs.pm/nerves/customizing-systems.html).
+systems](https://nerves.hexdocs.pm/customizing-systems.html).
 
 ## Preparing your BeagleBone
 
@@ -84,7 +84,7 @@ outside of any filesystem. Provisioning is an optional step and reasonable
 defaults are provided if this is missing.
 
 Provisioning information can be queried using the Nerves.Runtime KV store's
-[`Nerves.Runtime.KV.get/1`](https://hexdocs.pm/nerves_runtime/Nerves.Runtime.KV.html#get/1)
+[`Nerves.Runtime.KV.get/1`](https://nerves-runtime.hexdocs.pm/Nerves.Runtime.KV.html#get/1)
 function.
 
 Keys used by this system are:


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://nerves-runtime.hexdocs.pm/Nerves.Runtime.FwupOps.html): Status 404
❌ Verification failed for https://nerves.hexdocs.pm/customizing-systems.html): Status 301
⚠️ Verification finished: 4 success, 2 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>